### PR TITLE
Make getPhpFiles actually behave like PHP $_FILES

### DIFF
--- a/Form.php
+++ b/Form.php
@@ -173,8 +173,12 @@ class Form extends Link implements \ArrayAccess
         foreach ($this->getFiles() as $name => $value) {
             $qs = http_build_query(array($name => $value), '', '&');
             if (!empty($qs)) {
+                // Make the query string conform to PHP's $_FILES rejuggling behaviour
+                $qs = preg_replace('/%5B(.*?)%5D%5B(name|type|tmp_name|error|size)%5D=/', '%5B$2%5D%5B$1%5D=', $qs);
                 parse_str($qs, $expandedValue);
                 $varName = substr($name, 0, strlen(key($expandedValue)));
+                // PHP converts whitespaces, dots, opening brackets and dashes to underscore. See http://php.net/manual/de/language.variables.external.php#81080
+                $varName = preg_replace('/[ \.\[\-]+/', '_', $varName);
                 $values = array_replace_recursive($values, array($varName => current($expandedValue)));
             }
         }

--- a/Tests/FormTest.php
+++ b/Tests/FormTest.php
@@ -460,13 +460,13 @@ class FormTest extends \PHPUnit_Framework_TestCase
     public function testGetPhpFiles()
     {
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
-        $this->assertEquals(array('foo' => array('bar' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0))), $form->getPhpFiles(), '->getPhpFiles() converts keys with [] to arrays');
+        $this->assertEquals(array('foo' => array('name' => array('bar' => ''), 'type' => array('bar' => ''), 'tmp_name' => array('bar' => ''), 'error' => array('bar' => 4), 'size' => array('bar' => 0))), $form->getPhpFiles(), '->getPhpFiles() converts keys with [] to arrays');
 
         $form = $this->createForm('<form method="post"><input type="file" name="f.o o[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
-        $this->assertEquals(array('f.o o' => array('bar' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0))), $form->getPhpFiles(), '->getPhpFiles() preserves periods and spaces in names');
+        $this->assertEquals(array('f_o_o' => array('name' => array('bar' => ''), 'type' => array('bar' => ''), 'tmp_name' => array('bar' => ''), 'error' => array('bar' => 4), 'size' => array('bar' => 0))), $form->getPhpFiles(), '->getPhpFiles() converts periods and spaces in names');
 
         $form = $this->createForm('<form method="post"><input type="file" name="f.o o[bar][ba.z]" /><input type="file" name="f.o o[bar][]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
-        $this->assertEquals(array('f.o o' => array('bar' => array('ba.z' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0), array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)))), $form->getPhpFiles(), '->getPhpFiles() preserves periods and spaces in names recursively');
+        $this->assertEquals(array('f_o_o' => array('name' => array('bar' => array('ba.z' => '', 0 => '')), 'type' => array('bar' => array('ba.z' => '', 0 => '')), 'tmp_name' => array('bar' => array('ba.z' => '', 0 => '')), 'error' => array('bar' => array('ba.z' => 4, 0 => 4)), 'size' => array('bar' => array('ba.z' => 0, 0 => 0)))), $form->getPhpFiles(), '->getPhpFiles() converts periods and spaces in names only in first level');
     }
 
     /**


### PR DESCRIPTION
See bug #14021 (https://github.com/symfony/symfony/issues/14021).

This is by no means complete, as probably also getPhpValues should be fixed accordingly to "underscore" variable names.